### PR TITLE
Add option to use existing bridge interface

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ lxd_noreboot: true
 
 lxd_with_zfs_backend: false
 
+lxd_bridgeconf_use_bridge: "true"
+lxd_bridgeconf_bridge: "lxdbr0"
 lxd_bridgeconf_ipv4_addr: "10.252.116.1"
 lxd_bridgeconf_ipv4_netmask: "255.255.255.0"
 lxd_bridgeconf_ipv4_network: "10.252.116.1/24"

--- a/templates/lxd-bridge.j2
+++ b/templates/lxd-bridge.j2
@@ -3,12 +3,12 @@
 # It is recommended to update it by using "dpkg-reconfigure -p medium lxd"
 
 # Whether to setup a new bridge or use an existing one
-USE_LXD_BRIDGE="true"
+USE_LXD_BRIDGE="{{ lxd_bridgeconf_use_bridge }}"
 
 # Bridge name
 # This is still used even if USE_LXD_BRIDGE is set to false
 # set to an empty value to fully disable
-LXD_BRIDGE="lxdbr0"
+LXD_BRIDGE="{{ lxd_bridgeconf_bridge }}"
 
 # Update the "default" LXD profile
 UPDATE_PROFILE="true"


### PR DESCRIPTION
Not sure if you want to pull it in but I needed the ability to use an existing bridge interface.

E.g, with host_vars or group_vars set to the below values will setup LXD using an existing interface such as the "br0" bridge interface as setup here:   https://bayton.org/docs/linux/lxd/lxd-zfs-and-bridged-networking-on-ubuntu-16-04-lts/#part-2-configuration

---
lxd_bridgeconf_use_bridge: "false"
lxd_bridgeconf_bridge: "br0"
lxd_bridgeconf_ipv4_addr: ""
lxd_bridgeconf_ipv4_netmask: ""
lxd_bridgeconf_ipv4_network: ""
lxd_bridgeconf_ipv4_dhcp_range: ""
lxd_bridgeconf_ipv4_dhcp_max: ""
